### PR TITLE
ipq807x: add WAN LED for AX6/AX3600

### DIFF
--- a/target/linux/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq807x/base-files/etc/board.d/01_leds
@@ -1,0 +1,17 @@
+
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+board=$(board_name)
+
+case "$board" in
+redmi,ax6|\
+xiaomi,ax3600)
+	ucidef_set_led_netdev "wan" "WAN" "blue:network" "eth0"
+	;;
+esac
+
+board_config_flush
+
+exit 0


### PR DESCRIPTION
Add WAN LED config for both device using netdev trigger.

Signed-off-by: Zhijun You <hujy652@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
